### PR TITLE
deps: Bump cryptography and black to fix security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Pillow==10.4.0
 qrcode[pil]==7.4.2
 
 # Security
-cryptography==42.0.5
+cryptography==46.0.4
 python-dotenv==1.0.1
 
 # Utilities
@@ -33,5 +33,5 @@ python-json-logger==2.0.7
 # Development dependencies (optional)
 pytest==7.4.3
 pytest-asyncio==0.21.1
-black==23.12.1
+black==24.3.0
 flake8==6.1.0


### PR DESCRIPTION
Resolves 3 Dependabot security alerts:

- **cryptography** 42.0.5 -> 46.0.4: fixes vulnerable OpenSSL in wheels (low + medium)
- **black** 23.12.1 -> 24.3.0: fixes ReDoS vulnerability (medium)

Neither package is directly imported in the production code path (bot.py). cryptography is a transitive dependency; black is a dev-only formatter.